### PR TITLE
Update benchmark default for residual OCDB

### DIFF
--- a/relval-jenkins.sh
+++ b/relval-jenkins.sh
@@ -27,6 +27,7 @@ batchFlags=""
 reconstructInTemporaryDir=0
 recoTriggerOptions="\"\""
 export additionalRecOptions="TPC:useRAWorHLT;"
+export ALIEN_JDL_TARGETSTORAGERESIDUAL=local://./resOCDB
 percentProcessedFilesToContinue=100
 maxSecondsToWait=$(( 3600*24 ))
 nMaxChunks=0


### PR DESCRIPTION
The change is backwards-compatible: validations for old releases can be rerun using the new option.