### PR TITLE
Prevent error report from first SP OCDB run

### DIFF
--- a/jdl2makeflow
+++ b/jdl2makeflow
@@ -643,7 +643,7 @@ elif jdl["JobType"] == "Reco":
   # cpass0SpCalib
   jdls["cpass0SpCalib"] = \
     get_preprocessed_jdl(args.jdl,
-      override={ "Output": [ "log_archive.zip:*.log,*.list@disk=2",
+      override={ "Output": [ "log_archive.zip:*.log,*.list,*.log.old@disk=2",
                              "validation_report.txt",
                              "OCDB_SPC.tar.bz2",
                              "core*" ],

--- a/jdl2makeflow_helpers/cpass0SpCalib_fallback.sh
+++ b/jdl2makeflow_helpers/cpass0SpCalib_fallback.sh
@@ -16,7 +16,7 @@ grep -qE '^E-ProcessOutput:' ocdb.log &> /dev/null \
 [[ $ALITPCDCALIBRES_LIST ]] || { echo "Cannot rerun as external list \$ALITPCDCALIBRES_LIST was not set"; exit 1; }
 
 echo "Faking run by using external list $ALITPCDCALIBRES_LIST"
-mv ocdb.log ocdb_firstrun.log
+mv ocdb.log ocdb.log.old
 rm -f alitpcdcalibres.txt
 cat > copyHere.C <<EOF
 void copyHere() {


### PR DESCRIPTION
First OCDB run in the release validation might have expected low statistics,
we don't want these errors to be reported in the final validation report.